### PR TITLE
Solve issue #119: Excessive folders being created by FidRadDB

### DIFF
--- a/Source/FidradDB_api.py
+++ b/Source/FidradDB_api.py
@@ -1,25 +1,39 @@
 # from fidraddb_api.ocdb.api.OCDBApi import new_api, OCDBApi
 from ocdb.api.OCDBApi import new_api, OCDBApi
+import numpy as np
+import os
 
-def FidradDB_api(elem, date, cal_path):
+def FidradDB_choose_cal_char_file(elem, acq_time, cal_char_candidates):
+
+    # Listening of the date versioning of filtered calibration files
+    fileTimeStamps = np.array([int(os.path.basename(i).split('_')[-1].split('.')[0]) for i in cal_char_candidates])
+
+    cal_char_type = elem.split('_')[-1]
+
+    if cal_char_type == 'RADCAL':
+        # Selection of the closest calibration data file to the measuring date
+        fileTimeStamp = min(fileTimeStamps, key=lambda x: abs(x - int(acq_time)))
+    else:
+        # Selection of the closest char data file PRE-EXISTING to the measuring date
+        fileTimeStamp = np.max(fileTimeStamps[np.array(fileTimeStamps) < int(acq_time)])
+
+    # Selection of the corresponding calibration file
+    matching = [s for s in cal_char_candidates if str(fileTimeStamp) in os.path.basename(s)][0]
+
+    return matching
+
+def FidradDB_api(elem, acq_time, cal_path):
     
     #api server_url configuration
     api = new_api(server_url='https://ocdb.eumetsat.int')
 
     #FidradDB connection and listening of all files for input instrument (serial number + type)
-    list = OCDBApi.fidrad_list_files(api,elem)
-    
-    #Listening of the date versioning of filtered calibration files
-    date_list = [eval(i.split('_')[-1].split('.')[0]) for i in list] 
+    cal_char_candidates = OCDBApi.fidrad_list_files(api,elem)
 
-    #Selection of the closest calibration data file to the measuring date
-    closest_date = min(date_list, key=lambda x:abs(x-int(date)))
-    
-    #Selection of the corresponding calibration file
-    matching = [s for s in list if str(closest_date) in s]
+    matching = FidradDB_choose_cal_char_file(elem, acq_time, cal_char_candidates)
 
     # Download from FidRadDB of the selected file
-    OCDBApi.fidrad_download_file(api, matching[0], cal_path)
+    OCDBApi.fidrad_download_file(api, matching, cal_path)
  
 
     return None

--- a/Source/FidradDB_api.py
+++ b/Source/FidradDB_api.py
@@ -5,6 +5,9 @@ import os
 
 def FidradDB_choose_cal_char_file(elem, acq_time, cal_char_candidates):
 
+    if len(cal_char_candidates) == 0:
+        return
+
     # Listening of the date versioning of filtered calibration files
     fileTimeStamps = np.array([int(os.path.basename(i).split('_')[-1].split('.')[0]) for i in cal_char_candidates])
 
@@ -15,8 +18,10 @@ def FidradDB_choose_cal_char_file(elem, acq_time, cal_char_candidates):
         fileTimeStamp = min(fileTimeStamps, key=lambda x: abs(x - int(acq_time)))
     else:
         # Selection of the closest char data file PRE-EXISTING to the measuring date
-        fileTimeStamp = np.max(fileTimeStamps[np.array(fileTimeStamps) < int(acq_time)])
-
+        try:
+            fileTimeStamp = np.max(fileTimeStamps[np.array(fileTimeStamps) < int(acq_time)])
+        except:
+            fileTimeStamp = min(fileTimeStamps, key=lambda x: abs(x - int(acq_time)))
     # Selection of the corresponding calibration file
     matching = [s for s in cal_char_candidates if str(fileTimeStamp) in os.path.basename(s)][0]
 

--- a/Source/ProcessL1b.py
+++ b/Source/ProcessL1b.py
@@ -144,8 +144,10 @@ class ProcessL1b:
 
         for sensorID in sensorIDs:
             for cal_char_type in cal_char_types:
-                matchingFile = FidradDB_choose_cal_char_file('%s_%s' % (sensorID,cal_char_type), acq_time, cal_char_candidates)
-                Utilities.read_char(matchingFile, gp)
+                cal_char_candidates_subset = [f for f in cal_char_candidates if '%s_%s' % (sensorID,cal_char_type) in os.path.basename(f)]
+                matchingFile = FidradDB_choose_cal_char_file('%s_%s' % (sensorID,cal_char_type), acq_time, cal_char_candidates_subset)
+                if matchingFile is not None:
+                    Utilities.read_char(matchingFile, gp)
 
         if len(gp.datasets) < 23:
             print(f'Too few characterization files found: {len(gp.datasets)} of 23')
@@ -607,7 +609,7 @@ class ProcessL1b:
                 sensorIDs = Utilities.get_sensor_dict(node)
                 acq_datetime = datetime.strptime(node.attributes["TIME-STAMP"], "%a %b %d %H:%M:%S %Y")
                 acq_time = acq_datetime.strftime('%Y%m%d%H%M%S')
-                inpath = os.path.join('Data', 'FidRadDB_characterization', "SeaBird", acq_time)
+                inpath = os.path.join('Data', 'FidRadDB_characterization', "SeaBird")
                 print('FidRadDB Char dir:', inpath)
 
                 # FidRad DB connection and download of calibration files by api

--- a/Source/TriosL1B.py
+++ b/Source/TriosL1B.py
@@ -293,27 +293,18 @@ class TriosL1B:
                 print('Full-Char dir:', inpath)
 
             elif ConfigFile.settings['FidRadDB'] == 1:
-                sensorID = Utilities.get_sensor_dict(node)
+                sensorIDs = Utilities.get_sensor_dict(node)
                 acq_time = node.attributes["TIME-STAMP"].replace('_','')
-                inpath = os.path.join(PATH_TO_DATA, 'FidRadDB_characterization', "TriOS", acq_time)
+                inpath = os.path.join(PATH_TO_DATA, 'FidRadDB_characterization', "TriOS")
                 print('FidRadDB Char dir:', inpath)
 
                 # FidRad DB connection and download of calibration files by api
-                types = ['STRAY','RADCAL','POLAR','THERMAL','ANGULAR']
-                for sensor in sensorID:
-                    for sens_type in types:
+                cal_char_types = ['STRAY','RADCAL','POLAR','THERMAL','ANGULAR']
+                for sensorID in sensorIDs:
+                    for cal_char_type in cal_char_types:
                         try:
-                            FidradDB_api(sensor+'_'+sens_type, acq_time, inpath)
+                            FidradDB_api(sensorID+'_'+cal_char_type, acq_time, inpath)
                         except: None
-
-                # Check the number of cal files
-                cal_count = 0
-                for root_dir, cur_dir, files in os.walk(inpath):
-                    cal_count += len(files)
-                if cal_count !=12:
-                    print("The number of calibration files doesn't match with the required number (12).")
-                    print("Aborting")
-                    exit()
 
             node = ProcessL1b.read_unc_coefficient_frm(node, inpath)
             if node is None:


### PR DESCRIPTION
Now FidRadDB will store all cal/char files under /Data/FidRadDB_characterization/TriOS or /Data/FidRadDB_characterization/SeaBird. It will look for the closest in time RADCAL, and the closest "pre-existing" time for characterisations. If in the latter case this doesn't exist, it will choose the closest in time characterisation (TBD).