### PR TITLE
Fix issue #95: Remove unnecessary warning on 'non-positive' covariance matrix.

### DIFF
--- a/Source/ProcessInstrumentUncertainties.py
+++ b/Source/ProcessInstrumentUncertainties.py
@@ -1099,6 +1099,9 @@ class Instrument(ABC):
 
 
 class HyperOCR(Instrument):
+
+    warnings.filterwarnings("ignore", message="One of the provided covariance matrix is not positivedefinite. It has been slightly changed")
+
     def __init__(self):
         super().__init__()
         self.instrument = "HyperOCR"
@@ -1556,6 +1559,9 @@ class HyperOCR(Instrument):
 
 
 class Trios(Instrument):
+
+    warnings.filterwarnings("ignore", message="One of the provided covariance matrix is not positivedefinite. It has been slightly changed")
+
     def __init__(self):
         super().__init__()
 


### PR DESCRIPTION
Tested in linux.