### PR TITLE
force at least 2 ancillary timestamps to be selected in L1AQC

### DIFF
--- a/Source/ProcessL1aqc.py
+++ b/Source/ProcessL1aqc.py
@@ -215,11 +215,11 @@ class ProcessL1aqc:
             ancDateTime = ancData.columns["DATETIME"][0].copy()
 
             print('Removing non-pertinent ancillary data.')
-            lower = bisect.bisect_left(ancDateTime, min(esDateTime))
+            # lower = bisect.bisect_left(ancDateTime, min(esDateTime))
+            lower = np.abs([d-min(esDateTime) for d in ancDateTime]).argmin()
             lower = list(range(0,lower-1))
-            # add one point to upper limit to ensure that at least 2 ancillary 
-            # timestamp are selected when dealing with short cast
-            upper = bisect.bisect_right(ancDateTime, max(esDateTime))+1
+            # upper = bisect.bisect_right(ancDateTime, max(esDateTime))+1
+            upper = np.abs([d-max(esDateTime) for d in ancDateTime]).argmin()
             upper = list(range(upper,len(ancDateTime)))
             ancData.colDeleteRow(upper)
             ancData.colDeleteRow(lower)

--- a/Source/ProcessL1aqc.py
+++ b/Source/ProcessL1aqc.py
@@ -217,7 +217,9 @@ class ProcessL1aqc:
             print('Removing non-pertinent ancillary data.')
             lower = bisect.bisect_left(ancDateTime, min(esDateTime))
             lower = list(range(0,lower-1))
-            upper = bisect.bisect_right(ancDateTime, max(esDateTime))
+            # add one point to upper limit to ensure that at least 2 ancillary 
+            # timestamp are selected when dealing with short cast
+            upper = bisect.bisect_right(ancDateTime, max(esDateTime))+1
             upper = list(range(upper,len(ancDateTime)))
             ancData.colDeleteRow(upper)
             ancData.colDeleteRow(lower)


### PR DESCRIPTION
This is needed when the total length of a cast is shorter than the sampling rate of the ancillary data
solving issue #168 