### PR TITLE
Fix Issue #204, Failed BRDF needs a catch and resolution

### DIFF
--- a/Source/ocbrdf/brdf_model_L11.py
+++ b/Source/ocbrdf/brdf_model_L11.py
@@ -155,6 +155,11 @@ class L11:
         cC = (coeffs.Gw0 * bbw0 - Rrs0 * k0) * k0 + coeffs.Gw1 * bbw0 * bbw0
         bbp0 = solve_2nd_order_poly(cA, cB, cC)
 
+        # Assume bbp0 = 0 if solve_2nd_order_poly fails to retrieve non-negative numbers
+        # In this case activate bbp0_fail flag (which in turn activates QAA_fail)
+        bbp0_fail = (bbp0 < 0) | (np.isinf(bbp0)) | (np.isnan(bbp0))
+        bbp0 = xr.where(bbp0_fail, 0, bbp0)
+
         # Compute bbp slope and extrapolate at all bands
         gamma = self.gamma[0] * (1.0 - self.gamma[1] * np.exp(-self.gamma[2] * (rrs442 / rrs560)))
         bbp = bbp0 * np.power(band0 / self.bands, gamma)
@@ -168,8 +173,15 @@ class L11:
         cB = - (coeffs.Gw0 * self.bbw + coeffs.Gp0 * bbp)
         cC = - (coeffs.Gw1 * self.bbw *self.bbw + coeffs.Gp1 * bbp * bbp)
         k = solve_2nd_order_poly(cA, cB, cC)
-        # Set 0 to nan to avoid division by zero
-        k = xr.where(k > 0, k, np.nan)
+
+        # If k is not a positive value, then
+        #   i) k --> bbw + aw
+        #   ii) k_fail flag is activated
+        k_fail = (k <= 0) | (np.isinf(k)) | (np.isnan(k))
+        k = xr.where(k_fail, self.aw + self.bbw, k)
+
+        # Set QAA_fail is either bbp0_fail or k_fail are activated
+        ds['QAA_fail'] = (bbp0_fail) | (k_fail)
 
         # Compute final IOPs
         ds['omega_b'] = bb / k

--- a/Source/ocbrdf/brdf_model_M02.py
+++ b/Source/ocbrdf/brdf_model_M02.py
@@ -139,6 +139,12 @@ class M02:
         Rrs560 = Rrs.sel(bands=b560)
 
         # Compute the OC4ME "R"
+        # NB: Could be the case that Rrs[442-560]<0,
+        #   then ds['log10_chl_OC4ME_Ratio'] will be NaN.
+        #   then ds['log10_chl'] will be NaN.
+        #   then forward_mod0/forward_mod (in brdf_prototype, ocbrdf/main.py) will be NaN.
+        #   then ds['C_BRDF'] = NaN.
+        #   In this case, C_BRDF will be set to 1 and C_BRDF_flag will be raised (see brdf_prototype, ocbrdf/main.py).
         ds['log10_chl_OC4ME_Ratio'] = np.log10(np.max([Rrs442, Rrs490, Rrs510], axis=0) / Rrs560)
 
         ds['log10_chl'] = 0 * ds['log10_chl_OC4ME_Ratio']

--- a/Source/ocbrdf/brdf_model_O23.py
+++ b/Source/ocbrdf/brdf_model_O23.py
@@ -151,6 +151,11 @@ class O23:
         cC = (coeffs.Gw0 * bbw0 - Rrs0 * k0) * k0 + coeffs.Gw1 * bbw0 * bbw0
         bbp0 = solve_2nd_order_poly(cA, cB, cC)
 
+        # Assume bbp0 = 0 if solve_2nd_order_poly fails to retrieve non-negative numbers
+        # In this case activate bbp0_fail flag (which in turn activates QAA_fail)
+        bbp0_fail = (bbp0 < 0) | (np.isinf(bbp0)) | (np.isnan(bbp0))
+        bbp0 = xr.where(bbp0_fail, 0, bbp0)
+
         # Compute bbp slope and extrapolate at all bands
         gamma = self.gamma[0] * (1.0 - self.gamma[1] * np.power(rrs442 / rrs560, -self.gamma[2]))
         bbp = bbp0 * np.power(band0 / self.bands, gamma)
@@ -164,8 +169,15 @@ class O23:
         cB = - (coeffs.Gw0 * self.bbw + coeffs.Gp0 * bbp)
         cC = - (coeffs.Gw1 * self.bbw *self.bbw + coeffs.Gp1 * bbp * bbp)
         k = solve_2nd_order_poly(cA, cB, cC)
-        # Set 0 to nan to avoid division by zero
-        k = xr.where(k > 0, k, np.nan)
+
+        # If k is not a positive value, then
+        #   i) k --> bbw + aw
+        #   ii) k_fail flag is activated
+        k_fail = (k <= 0) | (np.isinf(k)) | (np.isnan(k))
+        k = xr.where(k_fail, self.aw + self.bbw, k)
+
+        # Set QAA_fail is either bbp0_fail or k_fail are activated
+        ds['QAA_fail'] = (bbp0_fail) | (k_fail)
 
         # Compute final IOPs
         ds['omega_b'] = bb / k

--- a/Source/ocbrdf/main.py
+++ b/Source/ocbrdf/main.py
@@ -83,9 +83,13 @@ def brdf_prototype(ds, adf=None, brdf_model='L11'):
         ds['C_brdf'] = xr.where(ds['convergeFlag'], ds['C_brdf'], forward_mod0 / forward_mod)
         ds['nrrs'] = ds['Rw'] / np.pi * ds['C_brdf']
 
-    # Flag BRDF where NaN and set to 1
+    # Flag BRDF where NaN and set to 1 (no correction applied).
     ds['C_brdf_fail'] = np.isnan(ds['C_brdf'])
     ds['C_brdf'] = xr.where(ds['C_brdf_fail'], 1, ds['C_brdf'])
+
+    # If QAA_fail is raised, raise C_brdf_fail (but still apply C_brdf).
+    if 'QAA_fail' in ds:
+        ds['C_brdf_fail'] = (ds['C_brdf_fail']) | (ds['QAA_fail'])
 
     # Compute uncertainty
     brdf_uncertainty(ds)
@@ -116,7 +120,7 @@ def brdf_uncertainty(ds, adf=None):
     # Compute absolute uncertainty of factor
     ds['brdf_unc'] = unc * ds['C_brdf']
 
-    # Flag BRDF where NaN and set to 1
+    # Flag BRDF_unc where NaN and set to 0
     ds['brdf_unc_fail'] = np.isnan(ds['brdf_unc'])
     ds['brdf_unc'] = xr.where(ds['brdf_unc_fail'], 0, ds['brdf_unc'])
 


### PR DESCRIPTION
L11: set k=aw+bbw when k<=0, set bbp0=0 when bbp0 and raise QAA_fail flag.
M02: Set C=1 when Chl=NaN, and raise QAA_fail flag.

TBD with C. Mazeran (Solvo)