### PR TITLE
fix #290 UnicodeDecodeError by ignoring the error

### DIFF
--- a/Source/RawFileReader.py
+++ b/Source/RawFileReader.py
@@ -1,5 +1,6 @@
 """Read raw Sea-Bird file"""
 import sys
+import logging
 
 from Source.Utilities import Utilities
 
@@ -29,8 +30,18 @@ class RawFileReader:
             str1 = hdr[sp1+1:sp2]
             str2 = hdr[sp2+2:end-1]
         else:
-            str1 = hdr[sp1+1:sp2].decode('utf-8')
-            str2 = hdr[sp2+2:end-1].decode('utf-8')
+            # str1 = hdr[sp1+1:sp2].decode('utf-8', 'ignore')
+            # str2 = hdr[sp2+2:end-1].decode('utf-8', 'ignore')
+
+            try:
+                str1 = hdr[sp1 + 1:sp2].decode('utf-8')
+                str2 = hdr[sp2 + 2:end - 1].decode('utf-8')
+            except UnicodeDecodeError:
+                logging.debug("HOCR raw header contains non UTF-8 encoded character")
+                str1 = hdr[sp1 + 1:sp2].decode('utf-8', 'ignore')
+                str2 = hdr[sp2 + 2:end - 1].decode('utf-8', 'ignore')
+
+
         #print(str1, str2)
 
         if len(str1) == 0:

--- a/Source/RawFileReader.py
+++ b/Source/RawFileReader.py
@@ -30,9 +30,6 @@ class RawFileReader:
             str1 = hdr[sp1+1:sp2]
             str2 = hdr[sp2+2:end-1]
         else:
-            # str1 = hdr[sp1+1:sp2].decode('utf-8', 'ignore')
-            # str2 = hdr[sp2+2:end-1].decode('utf-8', 'ignore')
-
             try:
                 str1 = hdr[sp1 + 1:sp2].decode('utf-8')
                 str2 = hdr[sp2 + 2:end - 1].decode('utf-8')


### PR DESCRIPTION
Add try except to recover for UnicodeDecodeError and for now just ignore the error (strips non utf-8 characters Bélanger becomes Blanger).
That way, if necessary, it will be easier in the future to add support for non utf-8 characters.