### PR TITLE
Fix Bundle Application & Partial Fix Application Testing

### DIFF
--- a/.github/actions/SetupEnvironment/action.yml
+++ b/.github/actions/SetupEnvironment/action.yml
@@ -29,7 +29,7 @@ runs:
       shell: bash -el {0}
       run: |
         mamba env update -n hypercp -f environment.yml
-        mamba install --channel=conda-forge pyinstaller==6.11
+        mamba install --channel=conda-forge pyinstaller
 
     - name: 📸 Capture Environment
       if: runner.os != 'Windows'
@@ -43,7 +43,7 @@ runs:
       shell: pwsh
       run: |
         mamba env update -n hypercp -f environment.yml
-        mamba install --channel=conda-forge pyinstaller==6.11
+        mamba install --channel=conda-forge pyinstaller
 
     - name: 📸 Capture Environment [Windows]
       if: runner.os == 'Windows'

--- a/.github/actions/SetupEnvironment/action.yml
+++ b/.github/actions/SetupEnvironment/action.yml
@@ -29,7 +29,7 @@ runs:
       shell: bash -el {0}
       run: |
         mamba env update -n hypercp -f environment.yml
-        mamba install --channel=conda-forge pyinstaller==6.6
+        mamba install --channel=conda-forge pyinstaller==6.12
 
     - name: 📸 Capture Environment
       if: runner.os != 'Windows'

--- a/.github/actions/SetupEnvironment/action.yml
+++ b/.github/actions/SetupEnvironment/action.yml
@@ -29,7 +29,7 @@ runs:
       shell: bash -el {0}
       run: |
         mamba env update -n hypercp -f environment.yml
-        mamba install --channel=conda-forge pyinstaller==6.12
+        mamba install --channel=conda-forge pyinstaller==6.11
 
     - name: 📸 Capture Environment
       if: runner.os != 'Windows'
@@ -43,7 +43,7 @@ runs:
       shell: pwsh
       run: |
         mamba env update -n hypercp -f environment.yml
-        mamba install --channel=conda-forge pyinstaller==6.6
+        mamba install --channel=conda-forge pyinstaller==6.11
 
     - name: 📸 Capture Environment [Windows]
       if: runner.os == 'Windows'

--- a/Main.py
+++ b/Main.py
@@ -614,9 +614,15 @@ class Command:
         super().__init__()
 
         # Confirm that core data files are in place. Download if necessary.
-        fpfZhang = os.path.join(CODE_HOME, "Data", "Zhang_rho_db.mat")
+        fpfZhang = os.path.join(CODE_HOME, "Data", "Zhang_rho_db_expanded.mat")
         if not os.path.exists(fpfZhang):
             Utilities.downloadZhangDB(fpfZhang, force=True)
+
+        # Confirm that core data files are in place. Download if necessary.
+        # fpfZhangLUT = os.path.join(CODE_HOME, "Data", "Zhang_rho_LUT.nc")
+        fpfZhangLUT = os.path.join(CODE_HOME, "Data", "Z17_LUT_v2.nc")
+        if not os.path.exists(fpfZhangLUT):
+            Utilities.downloadZhangLUT(fpfZhangLUT, force=True)
 
         # Create a default main config to be filled with cmd argument
         # to avoid reading the one generated with the GUI

--- a/Tests/test_sample_data.py
+++ b/Tests/test_sample_data.py
@@ -46,7 +46,7 @@ class TestSeabirdSolarTracker(unittest.TestCase):
         self.cfg_filename = os.path.join(root, "Config", "sample_SEABIRD_SOLARTRACKER.cfg")
         self.files = sorted(glob.glob(os.path.join(self.path_to_data, 'RAW', f'*.RAW')))
 
-    def test_pysas(self):
+    def test_seabird_solar_tracker(self):
         from Main import Command
         os.chdir(root)  # Need to switch to root as path in Config files are relative
         for file in self.files:

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: hypercp
+name: hypercp-test
 channels:
   - defaults
   - conda-forge
@@ -8,7 +8,7 @@ dependencies:
   - pyqt=5.15
   - requests=2.28
   - tqdm=4.65
-  - numpy=1.23
+  - numpy=1.26
   - h5py=3.7
   - pytz=2022.7
   - matplotlib
@@ -20,10 +20,11 @@ dependencies:
   - netcdf4=1.6
   - j6s
   - pytables=3.7
-  - pyspectral=0.12
+  - pyspectral=0.12.5
   - pyqtgraph
   - ocdb-client
   - pip
   - pip:
+    - comet_maths<=1.0.3
     - punpy
     - fpdf2


### PR DESCRIPTION
- Recent update of comet-maths required numpy 2 which broke other dependencies (e.g. h5py, pandas...). Added requirement to keep comet_maths<=1.0.3
- Force download of Zhango_rho_db_extended.mat and Z17_LUT_v2.nc in Command mode. To prevent GUI pop-up.

Fix #339 Bundle Application on all OS and Application Test on Ubuntu and macOS.
