### PR TITLE
Small PR

### DIFF
--- a/Source/ProcessInstrumentUncertainties.py
+++ b/Source/ProcessInstrumentUncertainties.py
@@ -336,9 +336,9 @@ class BaseInstrument(ABC):  # Inheriting ABC allows for more function decorators
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message="invalid value encountered in divide")
             # convert to relative in order to avoid a complex unit conversion process in ProcessL2.
-            ES_unc = es_unc / es
-            LI_unc = li_unc / li
-            LT_unc = lt_unc / lt
+            ES_unc = es_unc / np.abs(es)
+            LI_unc = li_unc / np.abs(li)
+            LT_unc = lt_unc / np.abs(lt)
 
         # interpolation step - bringing uncertainties to common wavebands from radiometric calibration wavebands.
         data_wvl = np.asarray(list(stats['ES']['std_Signal_Interpolated'].keys()),

--- a/Source/ProcessL1aTriOS.py
+++ b/Source/ProcessL1aTriOS.py
@@ -46,20 +46,48 @@ class ProcessL1aTriOS:
 
 
                 ## Test filename for station/cast
-                match1 = re.search(r'\d{8}_\d{6}', file.split('/')[-1])
-                match2 = re.search(r'\d{4}S', file.split('/')[-1])
-                match3 = re.search(r'\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}', file.split('/')[-1])
-                if match1 is not None:
-                    a_name = match1.group()
-                elif match2 is not None:
-                    a_name = match2.group()
-                elif match3 is not None:
-                    a_name = match3.group()
-                else:
+
+                def parse_filename(data):
+                    dates = []
+                    for pattern in [
+                        r'\d{8}.\d{6}', 
+                        r'\d{4}.\d{2}.\d{2}.\d{2}.\d{2}.\d{2}',
+                        r'\d{8}.\d{2}.\d{2}.\d{2}',
+                        r'\d{4}.\d{2}.\d{2}.\d{6}',
+                        r'\d{4}S', 
+                    ]:
+                        match = re.search(pattern, data)
+                        if match is not None:
+                            dates.append(match.group(0))
+                    
+                    if len(dates) == 0:
+                        raise IndexError
+                    
+                    return dates[0]
+                
+                try:
+                    a_name = parse_filename(file.split('/')[-1])
+                except IndexError:
                     print("  ERROR: no identifier recognized in TRIOS L0 file name" )
                     print("  L0 filename should have a cast to identify triplet instrument")
                     print("  ending in 4 digits before S.mlb ")
                     return None,None
+
+                # match1 = re.search(r'\d{8}_\d{6}', file.split('/')[-1])
+                # match2 = re.search(r'\d{4}S', file.split('/')[-1])
+                # match3 = re.search(r'\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}', file.split('/')[-1])
+                # # string except for serial number will be the same for a triplet
+                # if match1 is not None:
+                #     a_name = match1.group()
+                # elif match2 is not None:
+                #     a_name = match2.group()
+                # elif match3 is not None:
+                #     a_name = match3.group()
+                # else:
+                #     print("  ERROR: no identifier recognized in TRIOS L0 file name" )
+                #     print("  L0 filename should have a cast to identify triplet instrument")
+                #     print("  ending in 4 digits before S.mlb ")
+                #     return None,None
 
                 # acq_time.append(a_cast)
                 acq_name.append(a_name)
@@ -114,8 +142,8 @@ class ProcessL1aTriOS:
 
                 try:
                     new_name = file.split('/')[-1].split('.mlb')[0].split(f'SAM_{name}_RAW_SPECTRUM_')[1]
-                    if match2 is not None:
-                        new_name = new_name+'_'+str(start)
+                    if re.search(r'\d{4}S', file.split('/')[-1]) is not None:
+                        new_name = new_name+'_'+str(start)  # I'm not sure what match2 was supposed to find in ACRI's code - AR
                 except IndexError as err:
                     print(err)
                     msg = "possibly an error in naming of Raw files"

--- a/Source/ProcessL1b.py
+++ b/Source/ProcessL1b.py
@@ -113,8 +113,33 @@ class ProcessL1b:
 
 
         # Read sensor-specific radiometric calibration
+        import re
+        
+        cal_dates = []
+        for s in ['ES', 'LI', 'LT']:
+            save_delta = None
+            if ConfigFile.settings["SensorType"].lower() == "trios":
+                s_tag = root.getGroup(f"{s}").attributes['IDDevice'][-4:]
+            else:
+                s_tag = root.getGroup(f"{s}_LIGHT").attributes['FrameTag'][-4:]
+
+            for f in glob.glob(os.path.join(radcal_dir, f'*{s_tag}_RADCAL*')):
+                cal_date = datetime.strptime(re.search(r'\d{14}', f.split('/')[-1]).group(), "%Y%m%d%H%M%S")
+                meas_date = root.getGroup("ANCILLARY_METADATA").getDataset("DATETIME").data[0]
+                t_delta = cal_date - meas_date.replace(tzinfo=None)
+                
+                if save_delta is None and t_delta.total_seconds() < 0:
+                    save_delta = abs(t_delta.total_seconds())
+                
+                if t_delta.total_seconds() < 0 and abs(t_delta.total_seconds()) <= save_delta:
+                    save_cal_date = cal_date
+                    save_delta = abs(t_delta.total_seconds())
+            
+            cal_dates.append(save_cal_date)
+
         for f in glob.glob(os.path.join(radcal_dir, r'*RADCAL*')):
-            Utilities.read_char(f, gp)
+            if datetime.strptime(re.search(r'\d{14}', f.split('/')[-1]).group(), "%Y%m%d%H%M%S") in cal_dates:
+                Utilities.read_char(f, gp)
 
         # Unc dataset renaming
         Utilities.RenameUncertainties_Class(root)


### PR DESCRIPTION
Solves #311 and first step towards solving issue #330 - added ability to select best RADCAL file when multiple are present.
Made date selection from TriOS triplet filenames more robust
bugfix in PIU - stops negative uncertainties being created when signal is negative see #342 

Tested on:
- Sample_PySAS
- Sample_TriOS_NOTRACKER
- Tartu issue #311 files available on the box (including RADCAL)

