### PR TITLE
SoRad PR - now tested with SB anc (Tara wind data)

### DIFF
--- a/Source/ProcessL1bTriOS.py
+++ b/Source/ProcessL1bTriOS.py
@@ -412,11 +412,10 @@ class ProcessL1bTriOS:
         if ConfigFile.settings["bL1bCal"] == 1 or ConfigFile.settings["bL1bCal"] == 2:
             # Calculate 6S model
             # Run elsewhere for FRM-regime
-            print('Running sixS')
-
             sensortype = "ES"
-            if len(node.groups[0].datasets['ES'].data) > 2: # TJ - This condition has been added, as I noted 
-            #at least 3 measuremenst are needed for the 6S binning.
+            if len(node.groups[0].datasets['ES'].data) > 2: # TJ - This condition has been added, as I noted at least 3 measurements are needed for 6S
+                print('Running sixS')
+     
                 res_sixS = ProcessL1b_FRMCal.get_direct_irradiance_ratio(node, sensortype)
     
                 # Store sixS results in new group

--- a/Source/ProcessL1bTriOS.py
+++ b/Source/ProcessL1bTriOS.py
@@ -415,48 +415,50 @@ class ProcessL1bTriOS:
             print('Running sixS')
 
             sensortype = "ES"
-            # Irradiance direct and diffuse ratio
-            res_sixS = ProcessL1b_FRMCal.get_direct_irradiance_ratio(node, sensortype)
-
-            # Store sixS results in new group
-            grp = node.getGroup(sensortype)
-            solar_zenith = res_sixS['solar_zenith']
-            # ProcessL1b_FRMCal.get_direct_irradiance_ratio uses Es bands to run 6S and then works around bands that
-            #  don't have values from Tartu for full FRM. Here, use all the Es bands.
-            direct_ratio = res_sixS['direct_ratio']
-            diffuse_ratio = res_sixS['diffuse_ratio']
-            # sixS model irradiance is in W/m^2/um, scale by 10 to match HCP units
-            # model_irr = (res_sixS['direct_irr']+res_sixS['diffuse_irr']+res_sixS['env_irr'])[:,ind_raw_data]/10
-            model_irr = (res_sixS['direct_irr']+res_sixS['diffuse_irr']+res_sixS['env_irr'])/10
-            # model_irr = (res_sixS['direct_irr']+res_sixS['diffuse_irr']+res_sixS['env_irr'])[:,ind_nocal==False]/10
-
-            sixS_grp = node.addGroup("SIXS_MODEL")
-            for dsname in ["DATETAG", "TIMETAG2", "DATETIME"]:
-                # copy datetime dataset for interp process
-                ds = sixS_grp.addDataset(dsname)
-                ds.data = grp.getDataset(dsname).data
-
-            ds = sixS_grp.addDataset("sixS_irradiance")
-
-            irr_grp = node.getGroup('ES_L1AQC')
-            str_wvl = np.asarray(pd.DataFrame(irr_grp.getDataset(sensortype).data).columns)
-            ds_dt = np.dtype({'names': str_wvl,'formats': [np.float64]*len(str_wvl)})
-            rec_arr = np.rec.fromarrays(np.array(model_irr).transpose(), dtype=ds_dt)
-            ds.data = rec_arr
-
-            ds = sixS_grp.addDataset("direct_ratio")
-            ds_dt = np.dtype({'names': str_wvl,'formats': [np.float64]*len(str_wvl)})
-            rec_arr = np.rec.fromarrays(np.array(direct_ratio).transpose(), dtype=ds_dt)
-            ds.data = rec_arr
-
-            ds = sixS_grp.addDataset("diffuse_ratio")
-            ds_dt = np.dtype({'names': str_wvl,'formats': [np.float64]*len(str_wvl)})
-            rec_arr = np.rec.fromarrays(np.array(diffuse_ratio).transpose(), dtype=ds_dt)
-            ds.data = rec_arr
-
-            ds = sixS_grp.addDataset("solar_zenith")
-            ds.columns["solar_zenith"] = solar_zenith
-            ds.columnsToDataset()
+            if len(node.groups[0].datasets['ES'].data) > 2: # TJ - This condition has been added, as I noted 
+            #at least 3 measuremenst are needed for the 6S binning.
+                res_sixS = ProcessL1b_FRMCal.get_direct_irradiance_ratio(node, sensortype)
+    
+                # Store sixS results in new group
+                grp = node.getGroup(sensortype)
+                solar_zenith = res_sixS['solar_zenith']
+                # ProcessL1b_FRMCal.get_direct_irradiance_ratio uses Es bands to run 6S and then works around bands that
+                #  don't have values from Tartu for full FRM. Here, use all the Es bands.
+                direct_ratio = res_sixS['direct_ratio']
+                diffuse_ratio = res_sixS['diffuse_ratio']
+                # sixS model irradiance is in W/m^2/um, scale by 10 to match HCP units
+                # model_irr = (res_sixS['direct_irr']+res_sixS['diffuse_irr']+res_sixS['env_irr'])[:,ind_raw_data]/10
+                model_irr = (res_sixS['direct_irr']+res_sixS['diffuse_irr']+res_sixS['env_irr'])/10
+                # model_irr = (res_sixS['direct_irr']+res_sixS['diffuse_irr']+res_sixS['env_irr'])[:,ind_nocal==False]/10
+    
+                sixS_grp = node.addGroup("SIXS_MODEL")
+                for dsname in ["DATETAG", "TIMETAG2", "DATETIME"]:
+                    # copy datetime dataset for interp process
+                    ds = sixS_grp.addDataset(dsname)
+                    ds.data = grp.getDataset(dsname).data
+    
+                ds = sixS_grp.addDataset("sixS_irradiance")
+    
+                irr_grp = node.getGroup('ES_L1AQC')
+                str_wvl = np.asarray(pd.DataFrame(irr_grp.getDataset(sensortype).data).columns)
+                ds_dt = np.dtype({'names': str_wvl,'formats': [np.float64]*len(str_wvl)})
+                rec_arr = np.rec.fromarrays(np.array(model_irr).transpose(), dtype=ds_dt)
+                ds.data = rec_arr
+    
+                ds = sixS_grp.addDataset("direct_ratio")
+                ds_dt = np.dtype({'names': str_wvl,'formats': [np.float64]*len(str_wvl)})
+                rec_arr = np.rec.fromarrays(np.array(direct_ratio).transpose(), dtype=ds_dt)
+                ds.data = rec_arr
+    
+                ds = sixS_grp.addDataset("diffuse_ratio")
+                ds_dt = np.dtype({'names': str_wvl,'formats': [np.float64]*len(str_wvl)})
+                rec_arr = np.rec.fromarrays(np.array(diffuse_ratio).transpose(), dtype=ds_dt)
+                ds.data = rec_arr
+    
+                ds = sixS_grp.addDataset("solar_zenith")
+                ds.columns["solar_zenith"] = solar_zenith
+                ds.columnsToDataset()
+            
 
         ## Dark Correction & Absolute Calibration
         stats = {}

--- a/Source/ProcessL1b_FRMCal.py
+++ b/Source/ProcessL1b_FRMCal.py
@@ -81,9 +81,22 @@ class ProcessL1b_FRMCal:
         nband = len(wvl)
 
         # SIXS called over 3min bin
+        ## SIXS configuration
+        n_mesure = len(datetime)
+        nband = len(wvl)
+        
+        # SIXS called over 3min bin  - original code section in HyperCP Dev
+        # deltat = (datetime[-1]-datetime[0])/len(datetime)
+        # n_min = int(3*60//deltat.total_seconds())  # nb of mesures over a bin
+        # n_bin = len(datetime)//n_min  # nb of bin in a cast
+        # if len(datetime) % n_min != 0:
+            # +1 to account for last points that fall in the last bin (smaller than 3 min)
+         #   n_bin += 1
+        
+        # code section for, So-rad where I had issues with division by zero 
         deltat = (datetime[-1]-datetime[0])/len(datetime)
         n_min = int(3*60/deltat.total_seconds())  # nb of mesures over a bin
-        if n_min == 0:  #TJ - this if statement was extra code that I added to avoid division by zero (I have no idea if it is a sound thing to do!)
+        if n_min == 0:  
             n_min = n_min + 1
         n_bin = len(datetime)//(n_min)  # nb of bin in a cast
         if len(datetime) % n_min != 0:

--- a/Source/ProcessL1b_FRMCal.py
+++ b/Source/ProcessL1b_FRMCal.py
@@ -30,7 +30,7 @@ class ProcessL1b_FRMCal:
             # keys change depending on if the process is called at L1B or L2, store correct keys in dictionary
             if ConfigFile.settings['SensorType'].lower() == "seabird":
                 irad_key = f'{sensortype}_LIGHT_L1AQC'
-            elif ConfigFile.settings['SensorType'].lower() == 'trios':
+            elif ConfigFile.settings['SensorType'].lower() == 'trios' or  ConfigFile.settings['SensorType'].lower() == 'sorad':
                 irad_key = f'{sensortype}_L1AQC'
             else:
                 return False
@@ -89,7 +89,8 @@ class ProcessL1b_FRMCal:
         if len(datetime) % n_min != 0:
             # +1 to account for last points that fall in the last bin (smaller than 3 min)
             n_bin += 1
-     
+  
+        
         percent_direct_solar_irradiance = np.zeros((n_bin, nband))
         percent_diffuse_solar_irradiance = np.zeros((n_bin, nband))
         direct_solar_irradiance = np.zeros((n_bin, nband))

--- a/Source/ProcessL2.py
+++ b/Source/ProcessL2.py
@@ -2489,7 +2489,8 @@ class ProcessL2:
         node.attributes['ENSEMBLE_DURATION'] = str(ConfigFile.settings['fL2TimeInterval']) + ' sec'
 
         # Check to insure at least some data survived quality checks
-        if node.getGroup("REFLECTANCE").getDataset("Rrs_HYPER").data is None:
+        #if node.getGroup("REFLECTANCE").getDataset("Rrs_HYPER").data is None: - code breaks as data does not exist
+        if node.getGroup("REFLECTANCE").getDataset("Rrs_HYPER") is None:
             msg = "All data appear to have been eliminated from the file. Aborting."
             print(msg)
             Utilities.writeLogFile(msg)

--- a/Source/ProcessL2.py
+++ b/Source/ProcessL2.py
@@ -1704,7 +1704,7 @@ class ProcessL2:
         waveSubset = wavelength  # Only used for Zhang; No subsetting for threeC or Mobley corrections
         rhoVec = {}
 
-        Rho_Uncertainty_Obj = Propagate(M=100, cores=1)
+        Rho_Uncertainty_Obj = Propagate(M=10, cores=1)
 
         # Rho will be the same across the entire ensemble slice based on input averages
         if threeCRho:
@@ -1725,7 +1725,7 @@ class ProcessL2:
             # Model limitations: AOD 0 - 0.2, Solar zenith 0-60 deg, Wavelength 350-1000 nm.
 
             # reduce number of draws because of how computationally intensive the Zhang method is
-            Rho_Uncertainty_Obj = Propagate(M=100, cores=1)
+            Rho_Uncertainty_Obj = Propagate(M=10, cores=1)
 
             # Need to limit the input for the model limitations. This will also mean cutting out Li, Lt, and Es
             # from non-valid wavebands.

--- a/Source/RhoCorrections.py
+++ b/Source/RhoCorrections.py
@@ -235,29 +235,55 @@ class RhoCorrections:
         LUT = LUT.interp(wind=[0, 1, 2, 3, 4, 5, 7.5, 10, 12.5, 15], kwargs={"fill_value": "extrapolate"})
 
         try:
-            zhang_interp = spin.interpn(
-                points=(
-                    LUT.wind.values,
-                    LUT.aot.values,
-                    LUT.sza.values,
-                    LUT.relAz.values,
-                    LUT.sal.values,
-                    LUT.SST.values,
-                    LUT.wavelength.values
-                ),
-                values=LUT.Glint.values,
-                xi=(
-                    ws,
-                    aod,
-                    sza,
-                    rel_az,
-                    sal,
-                    wt,
-                    nwb
-                ),
-                method="pchip", # should be cubic - temporary fix due to memory issues
-            )
-            print('Interpolating ZLUT using pchip (3rd order Hermitian Polynomial) method')
+            if ConfigFile.settings['SensorType'].lower() == "sorad":
+                zhang_interp = spin.interpn(
+                    points=(
+                        LUT.wind.values,
+                        LUT.aot.values,
+                        LUT.sza.values,
+                        LUT.relAz.values,
+                        LUT.sal.values,
+                        LUT.SST.values,
+                        LUT.wavelength.values
+                    ),
+                    values=LUT.Glint.values,
+                    xi=(
+                        ws,
+                        aod,
+                        sza,
+                        rel_az,
+                        sal,
+                        wt,
+                        nwb
+                    ),
+                    method="pchip", # should be cubic - temporary fix due to memory issues
+                )
+                print('Interpolating Z17 LUT using pchip (3rd order Hermitian Polynomial) method')
+            else:
+                zhang_interp = spin.interpn(
+                    points=(
+                        LUT.wind.values,
+                        LUT.aot.values,
+                        LUT.sza.values,
+                        LUT.relAz.values,
+                        LUT.sal.values,
+                        LUT.SST.values,
+                        LUT.wavelength.values
+                    ),
+                    values=LUT.Glint.values,
+                    xi=(
+                        ws,
+                        aod,
+                        sza,
+                        rel_az,
+                        sal,
+                        wt,
+                        nwb
+                    ),
+                    method="cubic", 
+                )
+                print('Interpolating Z17 LUT using cubic method')
+            
         except ValueError as err:
             # will implement better error handling, in place until Z17 LUT is updated with all indexes
             raise InterpolationError(f"Interpolation of Z17 LUT failed with {err}")

--- a/Source/RhoCorrections.py
+++ b/Source/RhoCorrections.py
@@ -255,8 +255,9 @@ class RhoCorrections:
                     wt,
                     nwb
                 ),
-                method="linear", # should be cubic - temporary fix due to memory issues
+                method="pchip", # should be cubic - temporary fix due to memory issues
             )
+            print('Interpolating ZLUT using pchip (3rd order Hermitian Polynomial) method')
         except ValueError as err:
             # will implement better error handling, in place until Z17 LUT is updated with all indexes
             raise InterpolationError(f"Interpolation of Z17 LUT failed with {err}")

--- a/Source/Uncertainty_Analysis.py
+++ b/Source/Uncertainty_Analysis.py
@@ -548,8 +548,11 @@ class Propagate:
 
         # === The sensor ===
         # Current database is not limited near these values
-        sensor = {'ang': np.array([sva, 180 - relAz]), 'wv': np.array(waveBands)}
-
+        
+        # sensor = {'ang': np.array([sva, 180 - relAz]), 'wv': np.array(waveBands)}
+        relAz = np.min([180, 180 - relAz]) # TJ - I got an instance where rel_az was > 180, so added this as a fix
+        sensor = {'ang': np.array([sva,  relAz]), 'wv': np.array(waveBands)} 
+    
         rho = ZhangRho.get_sky_sun_rho(env, sensor)['rho']
 
         return rho

--- a/Source/Uncertainty_Analysis.py
+++ b/Source/Uncertainty_Analysis.py
@@ -550,7 +550,7 @@ class Propagate:
         # Current database is not limited near these values
         
         # sensor = {'ang': np.array([sva, 180 - relAz]), 'wv': np.array(waveBands)}
-        relAz = np.min([180, 180 - relAz]) # TJ - I got an instance where rel_az was > 180, so added this as a fix
+        relAz = np.min([180, 180 - relAz]) # TJ - I got an instance where rel_az was > 180, so added this as a fix.
         sensor = {'ang': np.array([sva,  relAz]), 'wv': np.array(waveBands)} 
     
         rho = ZhangRho.get_sky_sun_rho(env, sensor)['rho']


### PR DESCRIPTION
Hi Dirk, @oceancolorcoder,

I think this is a relatively minor PR compared to last time - key changes are:

  (i) Testing with ancillary wind file (example from Tara 2024 on Box). I think this all worked fine, no code-mods were needed, and the comparisons  I did with the ECWF data looked reasonable. I re-did the HyperPro match-ups with the Tara wind data, and the were similar order to before. 
  
  (ii)  pchip interpolation for Z17 LUT, as discussed online.
  
  (iii)  Steps to mitigate 6S failing. This is done both within the binning in ProcessL1B_FRM.cal (where I account for case of division by zero), and in ProcessL1B TriOS (where I test for min no. of ES measurements to run 6S). I believe that these mods were only needed for very sparse data (which never gets to the end of L2 anyway), as I first noticed this in an hourly segment with only a few records.

-------------------------------

I tested the PR-code on the sample datasets (output on the box). PySAS and TriOS both get to the end of L2 OK - output unchanged from previous. The Solartracker got stuck at L1B due to a timestamp-related error. I'll need check further if this is due to my changes, or perhaps how I have passed the Solar tracker sample data, as it is the first time I have tried to run it. 

I'm away next week, but should be along to the HyperCP meeting on April 24th. I'm confident that I can now bulk-process Tara data, so thanks so much for helping us with that big ESA deliverable.

Tom





